### PR TITLE
take a number of dimensions as argument

### DIFF
--- a/Classes/PresetInterpolatorServer.sc
+++ b/Classes/PresetInterpolatorServer.sc
@@ -1,8 +1,8 @@
 PresetInterpolatorServer : PresetInterpolator {
 	var <synth, <bus, def;
 
-	*new { arg model;
-		model = model ?? {InterpolatorServer()};
+	*new { arg model, dimensions=2;
+		model = model ?? {InterpolatorServer(dimensions)};
 		^super.newCopyArgs(model).init;
 	}
 	


### PR DESCRIPTION
This PR is meant as the start of a conversation on PresetInterpolatorServer's usage. The change I am proposing above will probably break existing code, and therefore should not be merged. Think of it as a suggestion that can be improved upon :)

I propose that PrIntSvr take a number of dimensions as an argument. Ideally, I think that the number of dimensions should be the only argument. This seems to work when omitting the model :
```supercollider
PresetInterpolatorServer(dimensions: 3);
```